### PR TITLE
Add example app and simple benchmark

### DIFF
--- a/benchmarks/simple_benchmark.py
+++ b/benchmarks/simple_benchmark.py
@@ -1,0 +1,15 @@
+"""Simple benchmark script for FastAPI."""
+
+import time
+from fastapi.testclient import TestClient
+from docs_src.example_project.main import app
+
+client = TestClient(app)
+
+if __name__ == "__main__":
+    start = time.perf_counter()
+    for _ in range(100):
+        response = client.get("/")
+        assert response.status_code == 200
+    duration = time.perf_counter() - start
+    print(f"100 requests took {duration:.4f} seconds")

--- a/docs/en/docs/performance-benchmarks.md
+++ b/docs/en/docs/performance-benchmarks.md
@@ -1,0 +1,10 @@
+# Performance Benchmarks
+
+You can run a simple benchmark locally with:
+
+```bash
+python benchmarks/simple_benchmark.py
+```
+
+This uses FastAPI's `TestClient` to make 100 requests to the example application
+and prints the total time taken.

--- a/docs/uk/docs/tutorial/sql-databases.md
+++ b/docs/uk/docs/tutorial/sql-databases.md
@@ -1,0 +1,7 @@
+/// warning
+
+The current page still doesn't have a translation for this language.
+
+But you can help translating it: [Contributing](https://fastapi.tiangolo.com/contributing/){.internal-link target=_blank}.
+
+///

--- a/docs_src/example_project/main.py
+++ b/docs_src/example_project/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello from example"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
     "starlette>=0.40.0,<0.47.0",
-    "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
+    "pydantic>=2.0.2,<3.0.0",
     "typing-extensions>=4.8.0",
 ]
 

--- a/tests/test_example_project.py
+++ b/tests/test_example_project.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from docs_src.example_project.main import app
+
+client = TestClient(app)
+
+
+def test_read_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello from example"}


### PR DESCRIPTION
## Summary
- update project to depend on Pydantic v2
- add a minimal example app
- include a basic benchmark script
- document running the benchmark
- mark SQL tutorial page as missing in Ukrainian docs
- test the example application

## Testing
- `ruff format docs_src/example_project/main.py tests/test_example_project.py benchmarks/simple_benchmark.py`
- `pytest tests/test_example_project.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_683e119a98f483238d524c8367663313